### PR TITLE
CoreParameters does not catch NumberFormatException

### DIFF
--- a/src/main/java/weiboclient4j/params/CoreParameters.java
+++ b/src/main/java/weiboclient4j/params/CoreParameters.java
@@ -29,7 +29,11 @@ public class CoreParameters {
     }
 
     public static Cid cid(String value) {
-        return new Cid(value);
+        try {
+            return new Cid(value);
+        } catch (NumberFormatException e) {
+            throw new NumberFormatException(String.format("Cid value [%s] is not a parsable Long", value));
+        }
     }
 
     public static City city(String value) {


### PR DESCRIPTION
`CoreParameters#cid(String)` calls `java.lang.long.parseLong` without first checking whether the argument parses. This lead to an uncaught `NumberFormatException`: [Oracle Java 7 API specification](http://docs.oracle.com/javase/7/docs/api/java/lang/Long.html#parseLong%28java.lang.String,%20int%29).

This pull request adds a check with a  more helpful exception message.

This also needs to be done for the following methods:

```
CoreParameters#id(String)
CoreParameters#uid(String)
CoreParameters#suid(String)
CoreParameters#targetUid(String)
CoreParameters#sourceUid(String)
CoreParameters#tagId.java(String)
```

 Kindly let me know if you want me to do same for them.
